### PR TITLE
Replace ‘i18n/translate’ with ‘i18n/translate/lang’

### DIFF
--- a/src/Http/api.routes.php
+++ b/src/Http/api.routes.php
@@ -12,7 +12,8 @@ Route::prefix('i18n')->group(function() {
 // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE
 
     Route::prefix('translate')->group(function() {
-        Route::post('/', 'I18nTranslation\TranslationController@store');
+        // replace "/" with "lang" in the route, for avoiding option method error
+        Route::post('/lang', 'I18nTranslation\TranslationController@store');
     });
 
     Route::prefix('translation')->group(function() {


### PR DESCRIPTION
This pull request includes a change to the `src/Http/api.routes.php` file to fix an issue with the route configuration for the translation endpoint.

Routing changes:

* [`src/Http/api.routes.php`](diffhunk://#diff-8ccc462db04e19d9dedbf504fd2c82b1d7942f82fcfd15fdf296d2cd6d1c5ac0L15-R16): Modified the route from `Route::post('/', 'I18nTranslation\TranslationController@store')` to `Route::post('/lang', 'I18nTranslation\TranslationController@store')` to avoid an options method error.