### PR TITLE
Dev

### DIFF
--- a/src/Services/I18nTranslationService.php
+++ b/src/Services/I18nTranslationService.php
@@ -77,7 +77,7 @@ class I18nTranslationService extends AbstractI18nTranslationService {
         } catch (ServiceException $e) {
             Log::error('[i18n\TranslationService\translate] Cannot translate because: ' . $e->getMessage());
 
-            return $data['text'];
+            return null;
         }
 
         // Get Language ID


### PR DESCRIPTION
This pull request includes a change to the `src/Http/api.routes.php` file to address an issue with the option method error in the translation route.

Routing change:

* [`src/Http/api.routes.php`](diffhunk://#diff-8ccc462db04e19d9dedbf504fd2c82b1d7942f82fcfd15fdf296d2cd6d1c5ac0L15-R16): Modified the route in the `translate` prefix from `"/"` to `"/lang"` to avoid an option method error.